### PR TITLE
Report group and user counts as a metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ following object types:
 * PaperlessTask
 * StoragePath
 * Tag
+* User
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ See the `--help` output for more flags.
 
 ## Permissions
 
-Since late 2023 Paperless-ngx [supports object
-permissions][paperless-permissions]. The metrics user requires _view_
-permissions on the following types:
+The metrics user requires [_view_ permissions][paperless-permissions] on the
+following object types:
 
 * Admin
   * Required for log analysis.
@@ -40,6 +39,7 @@ permissions on the following types:
 * Correspondent
 * Document
 * DocumentType
+* Group
 * PaperlessTask
 * StoragePath
 * Tag

--- a/collector.go
+++ b/collector.go
@@ -18,6 +18,7 @@ func newCollector(cl *client.Client, timeout time.Duration) prometheus.Collector
 			newTaskCollector(cl),
 			newLogCollector(cl),
 			newGroupCollector(cl),
+			newUserCollector(cl),
 		},
 	}
 }

--- a/collector.go
+++ b/collector.go
@@ -17,6 +17,7 @@ func newCollector(cl *client.Client, timeout time.Duration) prometheus.Collector
 			newStoragePathCollector(cl),
 			newTaskCollector(cl),
 			newLogCollector(cl),
+			newGroupCollector(cl),
 		},
 	}
 }

--- a/group.go
+++ b/group.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+
+	"github.com/hansmi/paperhooks/pkg/client"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type groupClient interface {
+	ListGroups(context.Context, client.ListGroupsOptions) ([]client.Group, *client.Response, error)
+}
+
+type groupCollector struct {
+	cl groupClient
+
+	countDesc *prometheus.Desc
+}
+
+func newGroupCollector(cl groupClient) *groupCollector {
+	return &groupCollector{
+		cl: cl,
+
+		countDesc: prometheus.NewDesc("paperless_groups",
+			"Number of user groups.",
+			nil, nil),
+	}
+}
+
+func (c *groupCollector) describe(ch chan<- *prometheus.Desc) {
+	ch <- c.countDesc
+}
+
+func (c *groupCollector) collect(ctx context.Context, ch chan<- prometheus.Metric) error {
+	_, response, err := c.cl.ListGroups(ctx, client.ListGroupsOptions{})
+
+	if err != nil {
+		return err
+	}
+
+	if response.ItemCount != client.ItemCountUnknown {
+		ch <- prometheus.MustNewConstMetric(c.countDesc, prometheus.GaugeValue,
+			float64(response.ItemCount))
+	}
+
+	return nil
+}

--- a/group_test.go
+++ b/group_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/hansmi/paperhooks/pkg/client"
+	"github.com/hansmi/prometheus-paperless-exporter/internal/testutil"
+)
+
+type fakeGroupClient struct {
+	count int64
+	err   error
+}
+
+func (c *fakeGroupClient) ListGroups(ctx context.Context, opts client.ListGroupsOptions) ([]client.Group, *client.Response, error) {
+	return nil, &client.Response{
+		ItemCount: c.count,
+	}, c.err
+}
+
+func TestGroup(t *testing.T) {
+	errTest := errors.New("test error")
+
+	for _, tc := range []struct {
+		name    string
+		cl      fakeGroupClient
+		wantErr error
+	}{
+		{
+			name: "empty",
+		},
+		{
+			name: "listing fails",
+			cl: fakeGroupClient{
+				err: errTest,
+			},
+			wantErr: errTest,
+		},
+		{
+			name: "groups",
+			cl: fakeGroupClient{
+				count: 987,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newGroupCollector(&tc.cl)
+
+			err := c.collect(context.Background(), testutil.DiscardMetrics(t))
+
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Error diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGroupCollect(t *testing.T) {
+	cl := fakeGroupClient{
+		count: client.ItemCountUnknown,
+	}
+
+	c := newMultiCollector(newGroupCollector(&cl))
+
+	testutil.CollectAndCompare(t, c, ``)
+
+	cl.count = 321
+
+	testutil.CollectAndCompare(t, c, `
+# HELP paperless_groups Number of user groups.
+# TYPE paperless_groups gauge
+paperless_groups 321
+`)
+}

--- a/user.go
+++ b/user.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+
+	"github.com/hansmi/paperhooks/pkg/client"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type userClient interface {
+	ListUsers(context.Context, client.ListUsersOptions) ([]client.User, *client.Response, error)
+}
+
+type userCollector struct {
+	cl userClient
+
+	countDesc *prometheus.Desc
+}
+
+func newUserCollector(cl userClient) *userCollector {
+	return &userCollector{
+		cl: cl,
+
+		countDesc: prometheus.NewDesc("paperless_users",
+			"Number of users.",
+			nil, nil),
+	}
+}
+
+func (c *userCollector) describe(ch chan<- *prometheus.Desc) {
+	ch <- c.countDesc
+}
+
+func (c *userCollector) collect(ctx context.Context, ch chan<- prometheus.Metric) error {
+	_, response, err := c.cl.ListUsers(ctx, client.ListUsersOptions{})
+
+	if err != nil {
+		return err
+	}
+
+	if response.ItemCount != client.ItemCountUnknown {
+		ch <- prometheus.MustNewConstMetric(c.countDesc, prometheus.GaugeValue,
+			float64(response.ItemCount))
+	}
+
+	return nil
+}

--- a/user_test.go
+++ b/user_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/hansmi/paperhooks/pkg/client"
+	"github.com/hansmi/prometheus-paperless-exporter/internal/testutil"
+)
+
+type fakeUserClient struct {
+	count int64
+	err   error
+}
+
+func (c *fakeUserClient) ListUsers(ctx context.Context, opts client.ListUsersOptions) ([]client.User, *client.Response, error) {
+	return nil, &client.Response{
+		ItemCount: c.count,
+	}, c.err
+}
+
+func TestUser(t *testing.T) {
+	errTest := errors.New("test error")
+
+	for _, tc := range []struct {
+		name    string
+		cl      fakeUserClient
+		wantErr error
+	}{
+		{
+			name: "empty",
+		},
+		{
+			name: "listing fails",
+			cl: fakeUserClient{
+				err: errTest,
+			},
+			wantErr: errTest,
+		},
+		{
+			name: "users",
+			cl: fakeUserClient{
+				count: 987,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newUserCollector(&tc.cl)
+
+			err := c.collect(context.Background(), testutil.DiscardMetrics(t))
+
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Error diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestUserCollect(t *testing.T) {
+	cl := fakeUserClient{
+		count: client.ItemCountUnknown,
+	}
+
+	c := newMultiCollector(newUserCollector(&cl))
+
+	testutil.CollectAndCompare(t, c, ``)
+
+	cl.count = 6799
+
+	testutil.CollectAndCompare(t, c, `
+# HELP paperless_users Number of users.
+# TYPE paperless_users gauge
+paperless_users 6799
+`)
+}


### PR DESCRIPTION
Requested in issue #41 by @tofuwabohu. Example metrics:

```
# HELP paperless_users Number of users.
# TYPE paperless_users gauge
paperless_users 6799

# HELP paperless_groups Number of user groups.
# TYPE paperless_groups gauge
paperless_groups 321
```