### PR TITLE
Add support for Statistics like total document count or number of documents per mime type

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -21,6 +21,7 @@ func newCollector(cl *client.Client, timeout time.Duration, enableRemoteNetwork 
 			newUserCollector(cl),
 			newDocumentCollector(cl),
 			newStatusCollector(cl),
+			newStatisticsCollector(cl),
 		},
 	}
 

--- a/collector_test.go
+++ b/collector_test.go
@@ -157,6 +157,27 @@ paperless_groups 10
 # HELP paperless_remote_version_update_available Whether an update is available.
 # TYPE paperless_remote_version_update_available gauge
 paperless_remote_version_update_available{version="v2.14.7"} 1
+# HELP paperless_statistics_character_count Number of characters stored across the total number of documents.
+# TYPE paperless_statistics_character_count gauge
+paperless_statistics_character_count 0
+# HELP paperless_statistics_correspondent_count Total number of correspondents.
+# TYPE paperless_statistics_correspondent_count gauge
+paperless_statistics_correspondent_count 0
+# HELP paperless_statistics_document_type_count Total number of document types.
+# TYPE paperless_statistics_document_type_count gauge
+paperless_statistics_document_type_count 0
+# HELP paperless_statistics_documents_inbox_count Total number of documents that have the defined 'Inbox' tag.
+# TYPE paperless_statistics_documents_inbox_count gauge
+paperless_statistics_documents_inbox_count 0
+# HELP paperless_statistics_documents_total Total number of documents.
+# TYPE paperless_statistics_documents_total gauge
+paperless_statistics_documents_total 0
+# HELP paperless_statistics_storage_path_count Total number of storage pathes.
+# TYPE paperless_statistics_storage_path_count gauge
+paperless_statistics_storage_path_count 0
+# HELP paperless_statistics_tag_count Total number of tags.
+# TYPE paperless_statistics_tag_count gauge
+paperless_statistics_tag_count 0
 # HELP paperless_status_celery_status Status of celery. 1 is OK, 0 is not OK.
 # TYPE paperless_status_celery_status gauge
 paperless_status_celery_status 0

--- a/collector_test.go
+++ b/collector_test.go
@@ -74,6 +74,36 @@ paperless_statistics_storage_path_count 0
 # HELP paperless_statistics_tag_count Total number of tags.
 # TYPE paperless_statistics_tag_count gauge
 paperless_statistics_tag_count 0
+# HELP paperless_status_celery_status Status of celery. 1 is OK, 0 is not OK.
+# TYPE paperless_status_celery_status gauge
+paperless_status_celery_status 0
+# HELP paperless_status_classifier_last_trained_timestamp_seconds Number of seconds since 01.01.1970 since the last time the classifier has been trained.
+# TYPE paperless_status_classifier_last_trained_timestamp_seconds gauge
+paperless_status_classifier_last_trained_timestamp_seconds -6.21355968e+10
+# HELP paperless_status_classifier_status Status of the classifier. 1 is OK, 0 is not OK.
+# TYPE paperless_status_classifier_status gauge
+paperless_status_classifier_status 0
+# HELP paperless_status_database_status Status of the database. 1 is OK, 0 is not OK.
+# TYPE paperless_status_database_status gauge
+paperless_status_database_status 0
+# HELP paperless_status_database_unapplied_migrations Number of unapplied database migrations.
+# TYPE paperless_status_database_unapplied_migrations gauge
+paperless_status_database_unapplied_migrations 0
+# HELP paperless_status_index_last_modified_timestamp_seconds Number of seconds since 01.01.1970 since the last time the index has been modified.
+# TYPE paperless_status_index_last_modified_timestamp_seconds gauge
+paperless_status_index_last_modified_timestamp_seconds -6.21355968e+10
+# HELP paperless_status_index_status Status of the index. 1 is OK, 0 is not OK.
+# TYPE paperless_status_index_status gauge
+paperless_status_index_status 0
+# HELP paperless_status_redis_status Status of redis. 1 is OK, 0 is not OK.
+# TYPE paperless_status_redis_status gauge
+paperless_status_redis_status 0
+# HELP paperless_status_storage_available_bytes Available storage of Paperless in bytes.
+# TYPE paperless_status_storage_available_bytes gauge
+paperless_status_storage_available_bytes 0
+# HELP paperless_status_storage_total_bytes Total storage of Paperless in bytes.
+# TYPE paperless_status_storage_total_bytes gauge
+paperless_status_storage_total_bytes 0
 # HELP paperless_users Number of users.
 # TYPE paperless_users gauge
 paperless_users 20

--- a/collector_test.go
+++ b/collector_test.go
@@ -53,36 +53,27 @@ paperless_task_status_info{status="success"} 1
 # HELP paperless_groups Number of user groups.
 # TYPE paperless_groups gauge
 paperless_groups 10
-# HELP paperless_status_celery_status Status of celery. 1 is OK, 0 is not OK.
-# TYPE paperless_status_celery_status gauge
-paperless_status_celery_status 0
-# HELP paperless_status_classifier_last_trained_timestamp_seconds Number of seconds since 01.01.1970 since the last time the classifier has been trained.
-# TYPE paperless_status_classifier_last_trained_timestamp_seconds gauge
-paperless_status_classifier_last_trained_timestamp_seconds -6.21355968e+10
-# HELP paperless_status_classifier_status Status of the classifier. 1 is OK, 0 is not OK.
-# TYPE paperless_status_classifier_status gauge
-paperless_status_classifier_status 0
-# HELP paperless_status_database_status Status of the database. 1 is OK, 0 is not OK.
-# TYPE paperless_status_database_status gauge
-paperless_status_database_status 0
-# HELP paperless_status_database_unapplied_migrations Number of unapplied database migrations.
-# TYPE paperless_status_database_unapplied_migrations gauge
-paperless_status_database_unapplied_migrations 0
-# HELP paperless_status_index_last_modified_timestamp_seconds Number of seconds since 01.01.1970 since the last time the index has been modified.
-# TYPE paperless_status_index_last_modified_timestamp_seconds gauge
-paperless_status_index_last_modified_timestamp_seconds -6.21355968e+10
-# HELP paperless_status_index_status Status of the index. 1 is OK, 0 is not OK.
-# TYPE paperless_status_index_status gauge
-paperless_status_index_status 0
-# HELP paperless_status_redis_status Status of redis. 1 is OK, 0 is not OK.
-# TYPE paperless_status_redis_status gauge
-paperless_status_redis_status 0
-# HELP paperless_status_storage_available_bytes Available storage of Paperless in bytes.
-# TYPE paperless_status_storage_available_bytes gauge
-paperless_status_storage_available_bytes 0
-# HELP paperless_status_storage_total_bytes Total storage of Paperless in bytes.
-# TYPE paperless_status_storage_total_bytes gauge
-paperless_status_storage_total_bytes 0
+# HELP paperless_statistics_character_count Number of characters stored across the total number of documents.
+# TYPE paperless_statistics_character_count gauge
+paperless_statistics_character_count 0
+# HELP paperless_statistics_correspondent_count Total number of correspondents.
+# TYPE paperless_statistics_correspondent_count gauge
+paperless_statistics_correspondent_count 0
+# HELP paperless_statistics_document_type_count Total number of document types.
+# TYPE paperless_statistics_document_type_count gauge
+paperless_statistics_document_type_count 0
+# HELP paperless_statistics_documents_inbox_count Total number of documents that have the defined 'Inbox' tag.
+# TYPE paperless_statistics_documents_inbox_count gauge
+paperless_statistics_documents_inbox_count 0
+# HELP paperless_statistics_documents_total Total number of documents.
+# TYPE paperless_statistics_documents_total gauge
+paperless_statistics_documents_total 0
+# HELP paperless_statistics_storage_path_count Total number of storage pathes.
+# TYPE paperless_statistics_storage_path_count gauge
+paperless_statistics_storage_path_count 0
+# HELP paperless_statistics_tag_count Total number of tags.
+# TYPE paperless_statistics_tag_count gauge
+paperless_statistics_tag_count 0
 # HELP paperless_users Number of users.
 # TYPE paperless_users gauge
 paperless_users 20

--- a/statistics.go
+++ b/statistics.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+
+	"github.com/hansmi/paperhooks/pkg/client"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type statisticsClient interface {
+	GetStatistics(context.Context) (*client.Statistics, *client.Response, error)
+}
+
+type statisticsCollector struct {
+	cl statisticsClient
+
+	documentsTotalDesc         *prometheus.Desc
+	documentsInboxDesc         *prometheus.Desc
+	documentFileTypeCountsDesc *prometheus.Desc
+	characterCountDesc         *prometheus.Desc
+	tagCountDesc               *prometheus.Desc
+	correspondentCountDesc     *prometheus.Desc
+	documentTypeCountDesc      *prometheus.Desc
+	storagePathCountDesc       *prometheus.Desc
+
+	// Missing fields from statistics: InboxTag, InboxTags, CurrentAsn
+}
+
+func newStatisticsCollector(cl statisticsClient) *statisticsCollector {
+	return &statisticsCollector{
+		cl: cl,
+
+		documentsTotalDesc:         prometheus.NewDesc("paperless_statistics_documents_total", "Total number of documents.", nil, nil),
+		documentsInboxDesc:         prometheus.NewDesc("paperless_statistics_documents_inbox_count", "Total number of documents that have the defined 'Inbox' tag.", nil, nil),
+		documentFileTypeCountsDesc: prometheus.NewDesc("paperless_statistics_documents_file_type_counts", "Total number of documents per MIME type.", []string{"mime_type"}, nil),
+		characterCountDesc:         prometheus.NewDesc("paperless_statistics_character_count", "Number of characters stored across the total number of documents.", nil, nil),
+		tagCountDesc:               prometheus.NewDesc("paperless_statistics_tag_count", "Total number of tags.", nil, nil),
+		correspondentCountDesc:     prometheus.NewDesc("paperless_statistics_correspondent_count", "Total number of correspondents.", nil, nil),
+		documentTypeCountDesc:      prometheus.NewDesc("paperless_statistics_document_type_count", "Total number of document types.", nil, nil),
+		storagePathCountDesc:       prometheus.NewDesc("paperless_statistics_storage_path_count", "Total number of storage pathes.", nil, nil),
+	}
+}
+
+func (c *statisticsCollector) describe(ch chan<- *prometheus.Desc) {
+	ch <- c.documentsTotalDesc
+	ch <- c.documentsInboxDesc
+	ch <- c.documentFileTypeCountsDesc
+	ch <- c.characterCountDesc
+	ch <- c.tagCountDesc
+	ch <- c.correspondentCountDesc
+	ch <- c.documentTypeCountDesc
+	ch <- c.storagePathCountDesc
+}
+
+func (c *statisticsCollector) collect(ctx context.Context, ch chan<- prometheus.Metric) error {
+	statistics, _, err := c.cl.GetStatistics(ctx)
+	if err != nil {
+		return err
+	}
+
+	ch <- prometheus.MustNewConstMetric(c.documentsTotalDesc, prometheus.GaugeValue, float64(statistics.DocumentsTotal))
+	ch <- prometheus.MustNewConstMetric(c.documentsInboxDesc, prometheus.GaugeValue, float64(statistics.DocumentsInbox))
+
+	for _, documentFileTypeCount := range statistics.DocumentFileTypeCounts {
+		ch <- prometheus.MustNewConstMetric(c.documentFileTypeCountsDesc, prometheus.GaugeValue, float64(documentFileTypeCount.MimeTypeCount), documentFileTypeCount.MimeType)
+	}
+
+	ch <- prometheus.MustNewConstMetric(c.characterCountDesc, prometheus.GaugeValue, float64(statistics.CharacterCount))
+	ch <- prometheus.MustNewConstMetric(c.tagCountDesc, prometheus.GaugeValue, float64(statistics.TagCount))
+	ch <- prometheus.MustNewConstMetric(c.correspondentCountDesc, prometheus.GaugeValue, float64(statistics.CorrespondentCount))
+	ch <- prometheus.MustNewConstMetric(c.documentTypeCountDesc, prometheus.GaugeValue, float64(statistics.DocumentTypeCount))
+	ch <- prometheus.MustNewConstMetric(c.storagePathCountDesc, prometheus.GaugeValue, float64(statistics.StoragePathCount))
+
+	return nil
+}

--- a/statistics_test.go
+++ b/statistics_test.go
@@ -21,7 +21,7 @@ func (c *fakeStatisticsClient) GetStatistics(ctx context.Context) (*client.Stati
 		DocumentsInbox: 273,
 		InboxTag:       1,
 		InboxTags:      []int64{1},
-		DocumentFileTypeCounts: []client.DocumentFileType{
+		DocumentFileTypeCounts: []client.StatisticsDocumentFileType{
 			{
 				MimeType:      "application/pdf",
 				MimeTypeCount: 1397,

--- a/statistics_test.go
+++ b/statistics_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/hansmi/paperhooks/pkg/client"
+	"github.com/hansmi/prometheus-paperless-exporter/internal/testutil"
+)
+
+type fakeStatisticsClient struct {
+	err error
+}
+
+func (c *fakeStatisticsClient) GetStatistics(ctx context.Context) (*client.Statistics, *client.Response, error) {
+	statistics := &client.Statistics{
+		DocumentsTotal: 1447,
+		DocumentsInbox: 273,
+		InboxTag:       1,
+		InboxTags:      []int64{1},
+		DocumentFileTypeCounts: []client.DocumentFileType{
+			{
+				MimeType:      "application/pdf",
+				MimeTypeCount: 1397,
+			},
+			{
+				MimeType:      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+				MimeTypeCount: 37,
+			},
+		},
+		CharacterCount:     11048372,
+		TagCount:           55,
+		CorrespondentCount: 201,
+		DocumentTypeCount:  42,
+		StoragePathCount:   0,
+		CurrentAsn:         0,
+	}
+	return statistics, &client.Response{}, c.err
+}
+
+func TestStatistics(t *testing.T) {
+	errTest := errors.New("test error")
+
+	for _, tc := range []struct {
+		name    string
+		cl      fakeStatisticsClient
+		wantErr error
+	}{
+		{
+			name: "empty",
+		},
+		{
+			name: "get statistics fails",
+			cl: fakeStatisticsClient{
+				err: errTest,
+			},
+			wantErr: errTest,
+		},
+		{
+			name: "get statistics works",
+			cl: fakeStatisticsClient{
+				err: nil,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newStatisticsCollector(&tc.cl)
+
+			err := c.collect(context.Background(), testutil.DiscardMetrics(t))
+
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Error diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestStatisticsCollect(t *testing.T) {
+	cl := fakeStatisticsClient{}
+
+	c := newMultiCollector(newStatisticsCollector(&cl))
+
+	testutil.CollectAndCompare(t, c, `
+# HELP paperless_statistics_character_count Number of characters stored across the total number of documents.
+# TYPE paperless_statistics_character_count gauge
+paperless_statistics_character_count 1.1048372e+07
+# HELP paperless_statistics_correspondent_count Total number of correspondents.
+# TYPE paperless_statistics_correspondent_count gauge
+paperless_statistics_correspondent_count 201
+# HELP paperless_statistics_document_type_count Total number of document types.
+# TYPE paperless_statistics_document_type_count gauge
+paperless_statistics_document_type_count 42
+# HELP paperless_statistics_documents_file_type_counts Total number of documents per MIME type.
+# TYPE paperless_statistics_documents_file_type_counts gauge
+paperless_statistics_documents_file_type_counts{mime_type="application/pdf"} 1397
+paperless_statistics_documents_file_type_counts{mime_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document"} 37
+# HELP paperless_statistics_documents_inbox_count Total number of documents that have the defined 'Inbox' tag.
+# TYPE paperless_statistics_documents_inbox_count gauge
+paperless_statistics_documents_inbox_count 273
+# HELP paperless_statistics_documents_total Total number of documents.
+# TYPE paperless_statistics_documents_total gauge
+paperless_statistics_documents_total 1447
+# HELP paperless_statistics_storage_path_count Total number of storage pathes.
+# TYPE paperless_statistics_storage_path_count gauge
+paperless_statistics_storage_path_count 0
+# HELP paperless_statistics_tag_count Total number of tags.
+# TYPE paperless_statistics_tag_count gauge
+paperless_statistics_tag_count 55
+`)
+}


### PR DESCRIPTION
This PR adds the standard paperless statistics (visible on the top right box in the paperless UI) into the export format.

## Dependency

This PR depends on https://github.com/hansmi/paperhooks/pull/43

## Output

```
# HELP paperless_statistics_character_count Number of characters stored across the total number of documents.
# TYPE paperless_statistics_character_count gauge
paperless_statistics_character_count 1.1048372e+07
# HELP paperless_statistics_correspondent_count Total number of correspondents.
# TYPE paperless_statistics_correspondent_count gauge
paperless_statistics_correspondent_count 201
# HELP paperless_statistics_document_type_count Total number of document types.
# TYPE paperless_statistics_document_type_count gauge
paperless_statistics_document_type_count 42
# HELP paperless_statistics_documents_file_type_counts Total number of documents per MIME type.
# TYPE paperless_statistics_documents_file_type_counts gauge
paperless_statistics_documents_file_type_counts{mime_type="application/msword"} 2
paperless_statistics_documents_file_type_counts{mime_type="application/pdf"} 1397
paperless_statistics_documents_file_type_counts{mime_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"} 6
paperless_statistics_documents_file_type_counts{mime_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document"} 37
paperless_statistics_documents_file_type_counts{mime_type="image/jpeg"} 4
paperless_statistics_documents_file_type_counts{mime_type="text/plain"} 1
# HELP paperless_statistics_documents_inbox_count Total number of documents that have the defined 'Inbox' tag.
# TYPE paperless_statistics_documents_inbox_count gauge
paperless_statistics_documents_inbox_count 273
# HELP paperless_statistics_documents_total Total number of documents.
# TYPE paperless_statistics_documents_total gauge
paperless_statistics_documents_total 1447
# HELP paperless_statistics_storage_path_count Total number of storage pathes.
# TYPE paperless_statistics_storage_path_count gauge
paperless_statistics_storage_path_count 0
# HELP paperless_statistics_tag_count Total number of tags.
# TYPE paperless_statistics_tag_count gauge
paperless_statistics_tag_count 55
```