### PR TITLE
Add support for Remote Version (incl. update available)

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -21,6 +21,7 @@ func newCollector(cl *client.Client, timeout time.Duration) prometheus.Collector
 			newUserCollector(cl),
 			newDocumentCollector(cl),
 			newStatusCollector(cl),
+			newRemoteVersionCollector(cl),
 		},
 	}
 }

--- a/collector.go
+++ b/collector.go
@@ -7,8 +7,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func newCollector(cl *client.Client, timeout time.Duration) prometheus.Collector {
-	return &multiCollector{
+func newCollector(cl *client.Client, timeout time.Duration, disableRemoteNetwork bool) prometheus.Collector {
+	multiCollector := &multiCollector{
 		timeout: timeout,
 		members: []multiCollectorMember{
 			newTagCollector(cl),
@@ -24,4 +24,10 @@ func newCollector(cl *client.Client, timeout time.Duration) prometheus.Collector
 			newRemoteVersionCollector(cl),
 		},
 	}
+
+	if !disableRemoteNetwork {
+		multiCollector.members = append(multiCollector.members, newRemoteVersionCollector(cl))
+	}
+
+	return multiCollector
 }

--- a/collector.go
+++ b/collector.go
@@ -21,7 +21,6 @@ func newCollector(cl *client.Client, timeout time.Duration, enableRemoteNetwork 
 			newUserCollector(cl),
 			newDocumentCollector(cl),
 			newStatusCollector(cl),
-			newRemoteVersionCollector(cl),
 		},
 	}
 

--- a/collector.go
+++ b/collector.go
@@ -7,7 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func newCollector(cl *client.Client, timeout time.Duration, disableRemoteNetwork bool) prometheus.Collector {
+func newCollector(cl *client.Client, timeout time.Duration, enableRemoteNetwork bool) prometheus.Collector {
 	multiCollector := &multiCollector{
 		timeout: timeout,
 		members: []multiCollectorMember{
@@ -25,7 +25,7 @@ func newCollector(cl *client.Client, timeout time.Duration, disableRemoteNetwork
 		},
 	}
 
-	if !disableRemoteNetwork {
+	if enableRemoteNetwork {
 		multiCollector.members = append(multiCollector.members, newRemoteVersionCollector(cl))
 	}
 

--- a/collector_test.go
+++ b/collector_test.go
@@ -136,6 +136,36 @@ paperless_groups 10
 # HELP paperless_remote_version_update_available Whether an update is available.
 # TYPE paperless_remote_version_update_available gauge
 paperless_remote_version_update_available{version="v2.14.7"} 1
+# HELP paperless_status_celery_status Status of celery. 1 is OK, 0 is not OK.
+# TYPE paperless_status_celery_status gauge
+paperless_status_celery_status 0
+# HELP paperless_status_classifier_last_trained_timestamp_seconds Number of seconds since 01.01.1970 since the last time the classifier has been trained.
+# TYPE paperless_status_classifier_last_trained_timestamp_seconds gauge
+paperless_status_classifier_last_trained_timestamp_seconds -6.21355968e+10
+# HELP paperless_status_classifier_status Status of the classifier. 1 is OK, 0 is not OK.
+# TYPE paperless_status_classifier_status gauge
+paperless_status_classifier_status 0
+# HELP paperless_status_database_status Status of the database. 1 is OK, 0 is not OK.
+# TYPE paperless_status_database_status gauge
+paperless_status_database_status 0
+# HELP paperless_status_database_unapplied_migrations Number of unapplied database migrations.
+# TYPE paperless_status_database_unapplied_migrations gauge
+paperless_status_database_unapplied_migrations 0
+# HELP paperless_status_index_last_modified_timestamp_seconds Number of seconds since 01.01.1970 since the last time the index has been modified.
+# TYPE paperless_status_index_last_modified_timestamp_seconds gauge
+paperless_status_index_last_modified_timestamp_seconds -6.21355968e+10
+# HELP paperless_status_index_status Status of the index. 1 is OK, 0 is not OK.
+# TYPE paperless_status_index_status gauge
+paperless_status_index_status 0
+# HELP paperless_status_redis_status Status of redis. 1 is OK, 0 is not OK.
+# TYPE paperless_status_redis_status gauge
+paperless_status_redis_status 0
+# HELP paperless_status_storage_available_bytes Available storage of Paperless in bytes.
+# TYPE paperless_status_storage_available_bytes gauge
+paperless_status_storage_available_bytes 0
+# HELP paperless_status_storage_total_bytes Total storage of Paperless in bytes.
+# TYPE paperless_status_storage_total_bytes gauge
+paperless_status_storage_total_bytes 0
 # HELP paperless_users Number of users.
 # TYPE paperless_users gauge
 paperless_users 20

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 var webConfig = webflag.AddFlags(kingpin.CommandLine, ":8081")
 var metricsPath = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics").Default("/metrics").String()
 var disableExporterMetrics = kingpin.Flag("web.disable-exporter-metrics", "Exclude metrics about the exporter itself").Bool()
+var disableRemoteNetwork = kingpin.Flag("disable-remote-network", "Exclude calls to API endpoints that require public internet access (e.g. checking for a paperless version)").Bool()
 var timeout = kingpin.Flag("scrape-timeout", "Maximum duration for a scrape").Default("1m").Duration()
 
 func main() {
@@ -40,7 +41,7 @@ func main() {
 	}
 
 	reg := prometheus.NewPedanticRegistry()
-	reg.MustRegister(newCollector(client, *timeout))
+	reg.MustRegister(newCollector(client, *timeout, *disableRemoteNetwork))
 
 	if !*disableExporterMetrics {
 		reg.MustRegister(

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 var webConfig = webflag.AddFlags(kingpin.CommandLine, ":8081")
 var metricsPath = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics").Default("/metrics").String()
 var disableExporterMetrics = kingpin.Flag("web.disable-exporter-metrics", "Exclude metrics about the exporter itself").Bool()
-var disableRemoteNetwork = kingpin.Flag("disable-remote-network", "Exclude calls to API endpoints that require public internet access (e.g. checking for a paperless version)").Bool()
+var enableRemoteNetwork = kingpin.Flag("enable-remote-network", "Include calls to API endpoints that require public internet access for your paperless instance (e.g. checking for a paperless version)").Bool()
 var timeout = kingpin.Flag("scrape-timeout", "Maximum duration for a scrape").Default("1m").Duration()
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func main() {
 	}
 
 	reg := prometheus.NewPedanticRegistry()
-	reg.MustRegister(newCollector(client, *timeout, *disableRemoteNetwork))
+	reg.MustRegister(newCollector(client, *timeout, *enableRemoteNetwork))
 
 	if !*disableExporterMetrics {
 		reg.MustRegister(

--- a/remote_version.go
+++ b/remote_version.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+
+	"github.com/hansmi/paperhooks/pkg/client"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type remoteVersionClient interface {
+	GetRemoteVersion(ctx context.Context) (*client.RemoteVersion, *client.Response, error)
+}
+
+type remoteVersionCollector struct {
+	cl remoteVersionClient
+
+	updateAvailableDesc *prometheus.Desc
+}
+
+func newRemoteVersionCollector(cl remoteVersionClient) *remoteVersionCollector {
+	return &remoteVersionCollector{
+		cl: cl,
+
+		updateAvailableDesc: prometheus.NewDesc("paperless_remote_version_update_available", "Whether an update is available.", []string{"version"}, nil),
+	}
+}
+
+func (c *remoteVersionCollector) describe(ch chan<- *prometheus.Desc) {
+	ch <- c.updateAvailableDesc
+}
+
+func (c *remoteVersionCollector) collect(ctx context.Context, ch chan<- prometheus.Metric) error {
+	remoteVersion, _, err := c.cl.GetRemoteVersion(ctx)
+	if err != nil {
+		return err
+	}
+
+	if len(remoteVersion.Version) == 0 {
+		return nil
+	}
+
+	var updateAvailable float64
+	if remoteVersion.UpdateAvailable {
+		updateAvailable = 1
+	} else {
+		updateAvailable = 0
+	}
+
+	ch <- prometheus.MustNewConstMetric(c.updateAvailableDesc, prometheus.GaugeValue, updateAvailable, remoteVersion.Version)
+
+	return nil
+}

--- a/remote_version.go
+++ b/remote_version.go
@@ -42,8 +42,6 @@ func (c *remoteVersionCollector) collect(ctx context.Context, ch chan<- promethe
 	var updateAvailable float64
 	if remoteVersion.UpdateAvailable {
 		updateAvailable = 1
-	} else {
-		updateAvailable = 0
 	}
 
 	ch <- prometheus.MustNewConstMetric(c.updateAvailableDesc, prometheus.GaugeValue, updateAvailable, remoteVersion.Version)

--- a/remote_version_test.go
+++ b/remote_version_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/hansmi/paperhooks/pkg/client"
+	"github.com/hansmi/prometheus-paperless-exporter/internal/testutil"
+)
+
+type fakeRemoteVersionClient struct {
+	err error
+}
+
+func (c *fakeRemoteVersionClient) GetRemoteVersion(ctx context.Context) (*client.RemoteVersion, *client.Response, error) {
+	return &client.RemoteVersion{
+		UpdateAvailable: true,
+		Version:         "1.2.3",
+	}, &client.Response{}, c.err
+}
+
+func TestRemoteVersion(t *testing.T) {
+	errTest := errors.New("test error")
+
+	for _, tc := range []struct {
+		name    string
+		cl      fakeRemoteVersionClient
+		wantErr error
+	}{
+		{
+			name: "empty",
+		},
+		{
+			name: "remote version fails",
+			cl: fakeRemoteVersionClient{
+				err: errTest,
+			},
+			wantErr: errTest,
+		},
+		{
+			name: "remote version suceeds",
+			cl:   fakeRemoteVersionClient{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newRemoteVersionCollector(&tc.cl)
+
+			err := c.collect(context.Background(), testutil.DiscardMetrics(t))
+
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Error diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestRemoteVersionCollect(t *testing.T) {
+	cl := fakeRemoteVersionClient{}
+
+	c := newMultiCollector(newRemoteVersionCollector(&cl))
+
+	testutil.CollectAndCompare(t, c, `
+# HELP paperless_remote_version_update_available Whether an update is available.
+# TYPE paperless_remote_version_update_available gauge
+paperless_remote_version_update_available{version="1.2.3"} 1
+`)
+}


### PR DESCRIPTION
This PR adds remote version + if an update is available into the export format.

## Dependency

This PR depends on https://github.com/hansmi/paperhooks/pull/42

## Output

```
# HELP paperless_remote_version_update_available Whether an update is available.
# TYPE paperless_remote_version_update_available gauge
paperless_remote_version_update_available{version="v2.14.7"} 0
```