### PR TITLE
Add support for Status (Database status, Index last trained, etc.)

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -20,6 +20,7 @@ func newCollector(cl *client.Client, timeout time.Duration) prometheus.Collector
 			newGroupCollector(cl),
 			newUserCollector(cl),
 			newDocumentCollector(cl),
+			newStatusCollector(cl),
 		},
 	}
 }

--- a/collector_test.go
+++ b/collector_test.go
@@ -13,6 +13,11 @@ import (
 )
 
 func TestCollector(t *testing.T) {
+	// Mocking time.Since
+	timeSince = func(t time.Time) time.Duration {
+		return time.Duration(5000000000) // 5 seconds
+	}
+
 	contentTypeJson := mime.FormatMediaType("application/json", nil)
 
 	mux := http.NewServeMux()
@@ -52,6 +57,9 @@ paperless_groups 10
 # HELP paperless_status_celery_status Status of celery. 1 is OK, 0 is not OK.
 # TYPE paperless_status_celery_status gauge
 paperless_status_celery_status 0
+# HELP paperless_status_classifier_last_trained Seconds since the last time the classifier has been trained.
+# TYPE paperless_status_classifier_last_trained gauge
+paperless_status_classifier_last_trained 5
 # HELP paperless_status_classifier_status Status of the classifier. 1 is OK, 0 is not OK.
 # TYPE paperless_status_classifier_status gauge
 paperless_status_classifier_status 0
@@ -61,6 +69,9 @@ paperless_status_database_status 0
 # HELP paperless_status_database_unapplied_migrations Number of unapplied database migrations.
 # TYPE paperless_status_database_unapplied_migrations gauge
 paperless_status_database_unapplied_migrations 0
+# HELP paperless_status_index_last_modified Seconds since the last time the index has been modified.
+# TYPE paperless_status_index_last_modified gauge
+paperless_status_index_last_modified 5
 # HELP paperless_status_index_status Status of the index. 1 is OK, 0 is not OK.
 # TYPE paperless_status_index_status gauge
 paperless_status_index_status 0

--- a/collector_test.go
+++ b/collector_test.go
@@ -13,11 +13,6 @@ import (
 )
 
 func TestCollector(t *testing.T) {
-	// Mocking time.Since
-	timeSince = func(t time.Time) time.Duration {
-		return time.Duration(5000000000) // 5 seconds
-	}
-
 	contentTypeJson := mime.FormatMediaType("application/json", nil)
 
 	mux := http.NewServeMux()
@@ -57,9 +52,9 @@ paperless_groups 10
 # HELP paperless_status_celery_status Status of celery. 1 is OK, 0 is not OK.
 # TYPE paperless_status_celery_status gauge
 paperless_status_celery_status 0
-# HELP paperless_status_classifier_last_trained_seconds Seconds since the last time the classifier has been trained.
-# TYPE paperless_status_classifier_last_trained_seconds gauge
-paperless_status_classifier_last_trained_seconds 5
+# HELP paperless_status_classifier_last_trained_timestamp_seconds Number of seconds since 01.01.1970 since the last time the classifier has been trained.
+# TYPE paperless_status_classifier_last_trained_timestamp_seconds gauge
+paperless_status_classifier_last_trained_timestamp_seconds -6.21355968e+10
 # HELP paperless_status_classifier_status Status of the classifier. 1 is OK, 0 is not OK.
 # TYPE paperless_status_classifier_status gauge
 paperless_status_classifier_status 0
@@ -69,9 +64,9 @@ paperless_status_database_status 0
 # HELP paperless_status_database_unapplied_migrations Number of unapplied database migrations.
 # TYPE paperless_status_database_unapplied_migrations gauge
 paperless_status_database_unapplied_migrations 0
-# HELP paperless_status_index_last_modified_seconds Seconds since the last time the index has been modified.
-# TYPE paperless_status_index_last_modified_seconds gauge
-paperless_status_index_last_modified_seconds 5
+# HELP paperless_status_index_last_modified_timestamp_seconds Number of seconds since 01.01.1970 since the last time the index has been modified.
+# TYPE paperless_status_index_last_modified_timestamp_seconds gauge
+paperless_status_index_last_modified_timestamp_seconds -6.21355968e+10
 # HELP paperless_status_index_status Status of the index. 1 is OK, 0 is not OK.
 # TYPE paperless_status_index_status gauge
 paperless_status_index_status 0

--- a/collector_test.go
+++ b/collector_test.go
@@ -57,9 +57,9 @@ paperless_groups 10
 # HELP paperless_status_celery_status Status of celery. 1 is OK, 0 is not OK.
 # TYPE paperless_status_celery_status gauge
 paperless_status_celery_status 0
-# HELP paperless_status_classifier_last_trained Seconds since the last time the classifier has been trained.
-# TYPE paperless_status_classifier_last_trained gauge
-paperless_status_classifier_last_trained 5
+# HELP paperless_status_classifier_last_trained_seconds Seconds since the last time the classifier has been trained.
+# TYPE paperless_status_classifier_last_trained_seconds gauge
+paperless_status_classifier_last_trained_seconds 5
 # HELP paperless_status_classifier_status Status of the classifier. 1 is OK, 0 is not OK.
 # TYPE paperless_status_classifier_status gauge
 paperless_status_classifier_status 0
@@ -69,21 +69,21 @@ paperless_status_database_status 0
 # HELP paperless_status_database_unapplied_migrations Number of unapplied database migrations.
 # TYPE paperless_status_database_unapplied_migrations gauge
 paperless_status_database_unapplied_migrations 0
-# HELP paperless_status_index_last_modified Seconds since the last time the index has been modified.
-# TYPE paperless_status_index_last_modified gauge
-paperless_status_index_last_modified 5
+# HELP paperless_status_index_last_modified_seconds Seconds since the last time the index has been modified.
+# TYPE paperless_status_index_last_modified_seconds gauge
+paperless_status_index_last_modified_seconds 5
 # HELP paperless_status_index_status Status of the index. 1 is OK, 0 is not OK.
 # TYPE paperless_status_index_status gauge
 paperless_status_index_status 0
 # HELP paperless_status_redis_status Status of redis. 1 is OK, 0 is not OK.
 # TYPE paperless_status_redis_status gauge
 paperless_status_redis_status 0
-# HELP paperless_status_storage_available Available storage of Paperless in bytes.
-# TYPE paperless_status_storage_available gauge
-paperless_status_storage_available 0
-# HELP paperless_status_storage_total Total storage of Paperless in bytes.
-# TYPE paperless_status_storage_total gauge
-paperless_status_storage_total 0
+# HELP paperless_status_storage_available_bytes Available storage of Paperless in bytes.
+# TYPE paperless_status_storage_available_bytes gauge
+paperless_status_storage_available_bytes 0
+# HELP paperless_status_storage_total_bytes Total storage of Paperless in bytes.
+# TYPE paperless_status_storage_total_bytes gauge
+paperless_status_storage_total_bytes 0
 # HELP paperless_users Number of users.
 # TYPE paperless_users gauge
 paperless_users 20

--- a/collector_test.go
+++ b/collector_test.go
@@ -49,6 +49,30 @@ paperless_task_status_info{status="success"} 1
 # HELP paperless_groups Number of user groups.
 # TYPE paperless_groups gauge
 paperless_groups 10
+# HELP paperless_status_celery_status Status of celery. 1 is OK, 0 is not OK.
+# TYPE paperless_status_celery_status gauge
+paperless_status_celery_status 0
+# HELP paperless_status_classifier_status Status of the classifier. 1 is OK, 0 is not OK.
+# TYPE paperless_status_classifier_status gauge
+paperless_status_classifier_status 0
+# HELP paperless_status_database_status Status of the database. 1 is OK, 0 is not OK.
+# TYPE paperless_status_database_status gauge
+paperless_status_database_status 0
+# HELP paperless_status_database_unapplied_migrations Number of unapplied database migrations.
+# TYPE paperless_status_database_unapplied_migrations gauge
+paperless_status_database_unapplied_migrations 0
+# HELP paperless_status_index_status Status of the index. 1 is OK, 0 is not OK.
+# TYPE paperless_status_index_status gauge
+paperless_status_index_status 0
+# HELP paperless_status_redis_status Status of redis. 1 is OK, 0 is not OK.
+# TYPE paperless_status_redis_status gauge
+paperless_status_redis_status 0
+# HELP paperless_status_storage_available Available storage of Paperless in bytes.
+# TYPE paperless_status_storage_available gauge
+paperless_status_storage_available 0
+# HELP paperless_status_storage_total Total storage of Paperless in bytes.
+# TYPE paperless_status_storage_total gauge
+paperless_status_storage_total 0
 # HELP paperless_users Number of users.
 # TYPE paperless_users gauge
 paperless_users 20

--- a/status.go
+++ b/status.go
@@ -9,7 +9,7 @@ import (
 )
 
 type statusClient interface {
-	GetStatus(ctx context.Context) (*client.Status, *client.Response, error)
+	GetStatus(ctx context.Context) (*client.SystemStatus, *client.Response, error)
 }
 
 type statusCollector struct {
@@ -92,13 +92,7 @@ func (c *statusCollector) isOK(status string) float64 {
 	return 0
 }
 
-func (c *statusCollector) elapsedSeconds(timestamp string) (float64, error) {
-	timeFormat := "2006-01-02T15:04:05.999999Z"
-	parsedTime, err := time.Parse(timeFormat, timestamp)
-	if err != nil {
-		return float64(0), err
-	}
-
+func (c *statusCollector) elapsedSeconds(parsedTime time.Time) (float64, error) {
 	duration := time.Since(parsedTime)
 	return float64(duration.Seconds()), nil
 }

--- a/status.go
+++ b/status.go
@@ -35,16 +35,16 @@ func newStatusCollector(cl statusClient) *statusCollector {
 	return &statusCollector{
 		cl: cl,
 
-		storageTotalDesc:                prometheus.NewDesc("paperless_status_storage_total", "Total storage of Paperless in bytes.", nil, nil),
-		storageAvailableDesc:            prometheus.NewDesc("paperless_status_storage_available", "Available storage of Paperless in bytes.", nil, nil),
+		storageTotalDesc:                prometheus.NewDesc("paperless_status_storage_total_bytes", "Total storage of Paperless in bytes.", nil, nil),
+		storageAvailableDesc:            prometheus.NewDesc("paperless_status_storage_available_bytes", "Available storage of Paperless in bytes.", nil, nil),
 		databaseStatusDesc:              prometheus.NewDesc("paperless_status_database_status", "Status of the database. 1 is OK, 0 is not OK.", nil, nil),
 		databaseUnappliedMigrationsDesc: prometheus.NewDesc("paperless_status_database_unapplied_migrations", "Number of unapplied database migrations.", nil, nil),
 		redisStatusDesc:                 prometheus.NewDesc("paperless_status_redis_status", "Status of redis. 1 is OK, 0 is not OK.", nil, nil),
 		celeryStatusDesc:                prometheus.NewDesc("paperless_status_celery_status", "Status of celery. 1 is OK, 0 is not OK.", nil, nil),
 		indexStatusDesc:                 prometheus.NewDesc("paperless_status_index_status", "Status of the index. 1 is OK, 0 is not OK.", nil, nil),
-		indexLastModifiedDesc:           prometheus.NewDesc("paperless_status_index_last_modified", "Seconds since the last time the index has been modified.", nil, nil),
+		indexLastModifiedDesc:           prometheus.NewDesc("paperless_status_index_last_modified_seconds", "Seconds since the last time the index has been modified.", nil, nil),
 		classifierStatusDesc:            prometheus.NewDesc("paperless_status_classifier_status", "Status of the classifier. 1 is OK, 0 is not OK.", nil, nil),
-		classifierLastTrainedDesc:       prometheus.NewDesc("paperless_status_classifier_last_trained", "Seconds since the last time the classifier has been trained.", nil, nil),
+		classifierLastTrainedDesc:       prometheus.NewDesc("paperless_status_classifier_last_trained_seconds", "Seconds since the last time the classifier has been trained.", nil, nil),
 	}
 }
 

--- a/status.go
+++ b/status.go
@@ -27,6 +27,9 @@ type statusCollector struct {
 	classifierLastTrainedDesc       *prometheus.Desc
 }
 
+// Only doing this to be able to unit test the collector
+var timeSince = time.Since
+
 func newStatusCollector(cl statusClient) *statusCollector {
 	return &statusCollector{
 		cl: cl,
@@ -93,6 +96,6 @@ func (c *statusCollector) isOK(status string) float64 {
 }
 
 func (c *statusCollector) elapsedSeconds(parsedTime time.Time) (float64, error) {
-	duration := time.Since(parsedTime)
+	duration := timeSince(parsedTime)
 	return float64(duration.Seconds()), nil
 }

--- a/status.go
+++ b/status.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/hansmi/paperhooks/pkg/client"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type statusClient interface {
+	GetStatus(ctx context.Context) (*client.Status, *client.Response, error)
+}
+
+type statusCollector struct {
+	cl statusClient
+
+	storageTotalDesc                *prometheus.Desc
+	storageAvailableDesc            *prometheus.Desc
+	databaseStatusDesc              *prometheus.Desc
+	databaseUnappliedMigrationsDesc *prometheus.Desc
+	redisStatusDesc                 *prometheus.Desc
+	celeryStatusDesc                *prometheus.Desc
+	indexStatusDesc                 *prometheus.Desc
+	indexLastModifiedDesc           *prometheus.Desc
+	classifierStatusDesc            *prometheus.Desc
+	classifierLastTrainedDesc       *prometheus.Desc
+}
+
+func newStatusCollector(cl statusClient) *statusCollector {
+	return &statusCollector{
+		cl: cl,
+
+		storageTotalDesc:                prometheus.NewDesc("paperless_status_storage_total", "Total storage of Paperless in bytes.", nil, nil),
+		storageAvailableDesc:            prometheus.NewDesc("paperless_status_storage_available", "Available storage of Paperless in bytes.", nil, nil),
+		databaseStatusDesc:              prometheus.NewDesc("paperless_status_database_status", "Status of the database. 1 is OK, 0 is not OK.", nil, nil),
+		databaseUnappliedMigrationsDesc: prometheus.NewDesc("paperless_status_database_unapplied_migrations", "Number of unapplied database migrations.", nil, nil),
+		redisStatusDesc:                 prometheus.NewDesc("paperless_status_redis_status", "Status of redis. 1 is OK, 0 is not OK.", nil, nil),
+		celeryStatusDesc:                prometheus.NewDesc("paperless_status_celery_status", "Status of celery. 1 is OK, 0 is not OK.", nil, nil),
+		indexStatusDesc:                 prometheus.NewDesc("paperless_status_index_status", "Status of the index. 1 is OK, 0 is not OK.", nil, nil),
+		indexLastModifiedDesc:           prometheus.NewDesc("paperless_status_index_last_modified", "Seconds since the last time the index has been modified.", nil, nil),
+		classifierStatusDesc:            prometheus.NewDesc("paperless_status_classifier_status", "Status of the classifier. 1 is OK, 0 is not OK.", nil, nil),
+		classifierLastTrainedDesc:       prometheus.NewDesc("paperless_status_classifier_last_trained", "Seconds since the last time the classifier has been trained.", nil, nil),
+	}
+}
+
+func (c *statusCollector) describe(ch chan<- *prometheus.Desc) {
+	ch <- c.storageTotalDesc
+	ch <- c.storageAvailableDesc
+	ch <- c.databaseStatusDesc
+	ch <- c.databaseUnappliedMigrationsDesc
+	ch <- c.redisStatusDesc
+	ch <- c.celeryStatusDesc
+	ch <- c.indexStatusDesc
+	ch <- c.indexLastModifiedDesc
+	ch <- c.classifierStatusDesc
+	ch <- c.classifierLastTrainedDesc
+}
+
+func (c *statusCollector) collect(ctx context.Context, ch chan<- prometheus.Metric) error {
+	status, _, err := c.cl.GetStatus(ctx)
+	if err != nil {
+		return err
+	}
+
+	ch <- prometheus.MustNewConstMetric(c.storageTotalDesc, prometheus.GaugeValue, float64(status.Storage.Total))
+	ch <- prometheus.MustNewConstMetric(c.storageAvailableDesc, prometheus.GaugeValue, float64(status.Storage.Available))
+	ch <- prometheus.MustNewConstMetric(c.databaseStatusDesc, prometheus.GaugeValue, c.isOK(status.Database.Status))
+	ch <- prometheus.MustNewConstMetric(c.databaseUnappliedMigrationsDesc, prometheus.GaugeValue, float64(len(status.Database.MigrationStatus.UnappliedMigrations)))
+	ch <- prometheus.MustNewConstMetric(c.redisStatusDesc, prometheus.GaugeValue, c.isOK(status.Tasks.RedisStatus))
+	ch <- prometheus.MustNewConstMetric(c.celeryStatusDesc, prometheus.GaugeValue, c.isOK(status.Tasks.CeleryStatus))
+	ch <- prometheus.MustNewConstMetric(c.indexStatusDesc, prometheus.GaugeValue, c.isOK(status.Tasks.IndexStatus))
+
+	if v, err := c.elapsedSeconds(status.Tasks.IndexLastModified); err == nil {
+		ch <- prometheus.MustNewConstMetric(c.indexLastModifiedDesc, prometheus.GaugeValue, v)
+	}
+
+	ch <- prometheus.MustNewConstMetric(c.classifierStatusDesc, prometheus.GaugeValue, c.isOK(status.Tasks.ClassifierStatus))
+
+	if v, err := c.elapsedSeconds(status.Tasks.ClassifierLastTrained); err == nil {
+		ch <- prometheus.MustNewConstMetric(c.classifierLastTrainedDesc, prometheus.GaugeValue, v)
+	}
+
+	return nil
+}
+
+func (c *statusCollector) isOK(status string) float64 {
+	if status == "OK" {
+		return 1
+	}
+
+	return 0
+}
+
+func (c *statusCollector) elapsedSeconds(timestamp string) (float64, error) {
+	timeFormat := "2006-01-02T15:04:05.999999Z"
+	parsedTime, err := time.Parse(timeFormat, timestamp)
+	if err != nil {
+		return float64(0), err
+	}
+
+	duration := time.Since(parsedTime)
+	return float64(duration.Seconds()), nil
+}

--- a/status.go
+++ b/status.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/hansmi/paperhooks/pkg/client"
@@ -88,7 +89,7 @@ func (c *statusCollector) collect(ctx context.Context, ch chan<- prometheus.Metr
 }
 
 func (c *statusCollector) isOK(status string) float64 {
-	if status == "OK" {
+	if strings.EqualFold(status, "OK") {
 		return 1
 	}
 

--- a/status_test.go
+++ b/status_test.go
@@ -51,6 +51,11 @@ func (c *fakeStatusClient) GetStatus(ctx context.Context) (*client.SystemStatus,
 }
 
 func TestStatus(t *testing.T) {
+	// Mocking time.Since
+	timeSince = func(t time.Time) time.Duration {
+		return time.Duration(5000000000) // 5 seconds
+	}
+
 	errTest := errors.New("test error")
 
 	for _, tc := range []struct {
@@ -94,6 +99,9 @@ func TestStatusCollect(t *testing.T) {
 # HELP paperless_status_celery_status Status of celery. 1 is OK, 0 is not OK.
 # TYPE paperless_status_celery_status gauge
 paperless_status_celery_status 1
+# HELP paperless_status_classifier_last_trained Seconds since the last time the classifier has been trained.
+# TYPE paperless_status_classifier_last_trained gauge
+paperless_status_classifier_last_trained 5
 # HELP paperless_status_classifier_status Status of the classifier. 1 is OK, 0 is not OK.
 # TYPE paperless_status_classifier_status gauge
 paperless_status_classifier_status 1
@@ -103,6 +111,9 @@ paperless_status_database_status 1
 # HELP paperless_status_database_unapplied_migrations Number of unapplied database migrations.
 # TYPE paperless_status_database_unapplied_migrations gauge
 paperless_status_database_unapplied_migrations 0
+# HELP paperless_status_index_last_modified Seconds since the last time the index has been modified.
+# TYPE paperless_status_index_last_modified gauge
+paperless_status_index_last_modified 5
 # HELP paperless_status_index_status Status of the index. 1 is OK, 0 is not OK.
 # TYPE paperless_status_index_status gauge
 paperless_status_index_status 1

--- a/status_test.go
+++ b/status_test.go
@@ -51,11 +51,6 @@ func (c *fakeStatusClient) GetStatus(ctx context.Context) (*client.SystemStatus,
 }
 
 func TestStatus(t *testing.T) {
-	// Mocking time.Since
-	timeSince = func(t time.Time) time.Duration {
-		return time.Duration(5000000000) // 5 seconds
-	}
-
 	errTest := errors.New("test error")
 
 	for _, tc := range []struct {
@@ -99,9 +94,9 @@ func TestStatusCollect(t *testing.T) {
 # HELP paperless_status_celery_status Status of celery. 1 is OK, 0 is not OK.
 # TYPE paperless_status_celery_status gauge
 paperless_status_celery_status 1
-# HELP paperless_status_classifier_last_trained_seconds Seconds since the last time the classifier has been trained.
-# TYPE paperless_status_classifier_last_trained_seconds gauge
-paperless_status_classifier_last_trained_seconds 5
+# HELP paperless_status_classifier_last_trained_timestamp_seconds Number of seconds since 01.01.1970 since the last time the classifier has been trained.
+# TYPE paperless_status_classifier_last_trained_timestamp_seconds gauge
+paperless_status_classifier_last_trained_timestamp_seconds 1.740168301e+09
 # HELP paperless_status_classifier_status Status of the classifier. 1 is OK, 0 is not OK.
 # TYPE paperless_status_classifier_status gauge
 paperless_status_classifier_status 1
@@ -111,9 +106,9 @@ paperless_status_database_status 1
 # HELP paperless_status_database_unapplied_migrations Number of unapplied database migrations.
 # TYPE paperless_status_database_unapplied_migrations gauge
 paperless_status_database_unapplied_migrations 0
-# HELP paperless_status_index_last_modified_seconds Seconds since the last time the index has been modified.
-# TYPE paperless_status_index_last_modified_seconds gauge
-paperless_status_index_last_modified_seconds 5
+# HELP paperless_status_index_last_modified_timestamp_seconds Number of seconds since 01.01.1970 since the last time the index has been modified.
+# TYPE paperless_status_index_last_modified_timestamp_seconds gauge
+paperless_status_index_last_modified_timestamp_seconds 1.740096114e+09
 # HELP paperless_status_index_status Status of the index. 1 is OK, 0 is not OK.
 # TYPE paperless_status_index_status gauge
 paperless_status_index_status 1

--- a/status_test.go
+++ b/status_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -15,35 +16,35 @@ type fakeStatusClient struct {
 	err error
 }
 
-func (c *fakeStatusClient) GetStatus(ctx context.Context) (*client.Status, *client.Response, error) {
-	return &client.Status{
+func (c *fakeStatusClient) GetStatus(ctx context.Context) (*client.SystemStatus, *client.Response, error) {
+	return &client.SystemStatus{
 		PNGXVersion: "2.14.7",
 		ServerOS:    "Linux-6.8.12-8-pve-x86_64-with-glibc2.36",
 		InstallType: "bare-metal",
-		Storage: client.StorageStatus{
+		Storage: client.SystemStatusStorage{
 			Total:     21474836480,
 			Available: 13406437376,
 		},
-		Database: client.DatabaseStatus{
+		Database: client.SystemStatusDatabase{
 			Type:   "postgresql",
 			URL:    "paperlessdb",
 			Status: "OK",
 			Error:  "",
-			MigrationStatus: client.DatabaseMigrationStatus{
+			MigrationStatus: client.SystemStatusDatabaseMigration{
 				LatestMigration:     "mfa.0003_authenticator_type_uniq",
 				UnappliedMigrations: []string{},
 			},
 		},
-		Tasks: client.TasksStatus{
+		Tasks: client.SystemStatusTasks{
 			RedisURL:              "redis://localhost:6379",
 			RedisStatus:           "OK",
 			RedisError:            "",
 			CeleryStatus:          "OK",
 			IndexStatus:           "OK",
-			IndexLastModified:     "999902-21T00:01:54.773392Z",
+			IndexLastModified:     time.Date(2025, time.February, 21, 0, 1, 54, 773392000, time.UTC),
 			IndexError:            "",
 			ClassifierStatus:      "OK",
-			ClassifierLastTrained: "999902-21T20:05:01.589548Z",
+			ClassifierLastTrained: time.Date(2025, time.February, 21, 20, 5, 1, 589548000, time.UTC),
 			ClassifierError:       "",
 		},
 	}, &client.Response{}, c.err

--- a/status_test.go
+++ b/status_test.go
@@ -99,9 +99,9 @@ func TestStatusCollect(t *testing.T) {
 # HELP paperless_status_celery_status Status of celery. 1 is OK, 0 is not OK.
 # TYPE paperless_status_celery_status gauge
 paperless_status_celery_status 1
-# HELP paperless_status_classifier_last_trained Seconds since the last time the classifier has been trained.
-# TYPE paperless_status_classifier_last_trained gauge
-paperless_status_classifier_last_trained 5
+# HELP paperless_status_classifier_last_trained_seconds Seconds since the last time the classifier has been trained.
+# TYPE paperless_status_classifier_last_trained_seconds gauge
+paperless_status_classifier_last_trained_seconds 5
 # HELP paperless_status_classifier_status Status of the classifier. 1 is OK, 0 is not OK.
 # TYPE paperless_status_classifier_status gauge
 paperless_status_classifier_status 1
@@ -111,20 +111,20 @@ paperless_status_database_status 1
 # HELP paperless_status_database_unapplied_migrations Number of unapplied database migrations.
 # TYPE paperless_status_database_unapplied_migrations gauge
 paperless_status_database_unapplied_migrations 0
-# HELP paperless_status_index_last_modified Seconds since the last time the index has been modified.
-# TYPE paperless_status_index_last_modified gauge
-paperless_status_index_last_modified 5
+# HELP paperless_status_index_last_modified_seconds Seconds since the last time the index has been modified.
+# TYPE paperless_status_index_last_modified_seconds gauge
+paperless_status_index_last_modified_seconds 5
 # HELP paperless_status_index_status Status of the index. 1 is OK, 0 is not OK.
 # TYPE paperless_status_index_status gauge
 paperless_status_index_status 1
 # HELP paperless_status_redis_status Status of redis. 1 is OK, 0 is not OK.
 # TYPE paperless_status_redis_status gauge
 paperless_status_redis_status 1
-# HELP paperless_status_storage_available Available storage of Paperless in bytes.
-# TYPE paperless_status_storage_available gauge
-paperless_status_storage_available 1.3406437376e+10
-# HELP paperless_status_storage_total Total storage of Paperless in bytes.
-# TYPE paperless_status_storage_total gauge
-paperless_status_storage_total 2.147483648e+10
+# HELP paperless_status_storage_available_bytes Available storage of Paperless in bytes.
+# TYPE paperless_status_storage_available_bytes gauge
+paperless_status_storage_available_bytes 1.3406437376e+10
+# HELP paperless_status_storage_total_bytes Total storage of Paperless in bytes.
+# TYPE paperless_status_storage_total_bytes gauge
+paperless_status_storage_total_bytes 2.147483648e+10
 `)
 }


### PR DESCRIPTION
This PR adds status (incl. Database status, Index last trained, etc.) into the export format.

## Dependency

This PR depends on https://github.com/hansmi/paperhooks/pull/44

## Output

```
# HELP paperless_status_celery_status Status of celery. 1 is OK, 0 is not OK.
# TYPE paperless_status_celery_status gauge
paperless_status_celery_status 1
# HELP paperless_status_classifier_last_trained Seconds since the last time the classifier has been trained.
# TYPE paperless_status_classifier_last_trained gauge
paperless_status_classifier_last_trained 3040.042041
# HELP paperless_status_classifier_status Status of the classifier. 1 is OK, 0 is not OK.
# TYPE paperless_status_classifier_status gauge
paperless_status_classifier_status 1
# HELP paperless_status_database_status Status of the database. 1 is OK, 0 is not OK.
# TYPE paperless_status_database_status gauge
paperless_status_database_status 1
# HELP paperless_status_database_unapplied_migrations Number of unapplied database migrations.
# TYPE paperless_status_database_unapplied_migrations gauge
paperless_status_database_unapplied_migrations 0
# HELP paperless_status_index_last_modified Seconds since the last time the index has been modified.
# TYPE paperless_status_index_last_modified gauge
paperless_status_index_last_modified 35672.675364
# HELP paperless_status_index_status Status of the index. 1 is OK, 0 is not OK.
# TYPE paperless_status_index_status gauge
paperless_status_index_status 1
# HELP paperless_status_redis_status Status of redis. 1 is OK, 0 is not OK.
# TYPE paperless_status_redis_status gauge
paperless_status_redis_status 1
# HELP paperless_status_storage_available Available storage of Paperless in bytes.
# TYPE paperless_status_storage_available gauge
paperless_status_storage_available 1.3408272384e+10
# HELP paperless_status_storage_total Total storage of Paperless in bytes.
# TYPE paperless_status_storage_total gauge
paperless_status_storage_total 2.147483648e+10
```