### PR TITLE
Improve error handling for remote version metric

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -26,8 +26,8 @@ func newCollector(cl *client.Client, timeout time.Duration, enableRemoteNetwork 
 		members = append(members, newRemoteVersionCollector(cl))
 	}
 
-	return &multiCollector{
-		timeout: timeout,
-		members: members,
-	}
+	c := newMultiCollector(members...)
+	c.timeout = timeout
+
+	return c
 }

--- a/collector_test.go
+++ b/collector_test.go
@@ -119,6 +119,9 @@ paperless_users 20
 # HELP paperless_documents Number of documents.
 # TYPE paperless_documents gauge
 paperless_documents 30
+# HELP paperless_warnings_total Number of warnings generated while scraping metrics.
+# TYPE paperless_warnings_total gauge
+paperless_warnings_total 0
 `)
 
 			if enableRemoteNetwork {

--- a/correspondent_test.go
+++ b/correspondent_test.go
@@ -72,7 +72,7 @@ func TestCorrespondent(t *testing.T) {
 func TestCorrespondentCollect(t *testing.T) {
 	cl := fakeCorrespondentClient{}
 
-	c := newMultiCollector(newCorrespondentCollector(&cl))
+	c := newMultiCollectorForTest(t, newCorrespondentCollector(&cl))
 
 	testutil.CollectAndCompare(t, c, `
 # HELP paperless_warnings_total Number of warnings generated while scraping metrics.

--- a/correspondent_test.go
+++ b/correspondent_test.go
@@ -74,7 +74,11 @@ func TestCorrespondentCollect(t *testing.T) {
 
 	c := newMultiCollector(newCorrespondentCollector(&cl))
 
-	testutil.CollectAndCompare(t, c, ``)
+	testutil.CollectAndCompare(t, c, `
+# HELP paperless_warnings_total Number of warnings generated while scraping metrics.
+# TYPE paperless_warnings_total gauge
+paperless_warnings_total 0
+`)
 
 	cl.items = append(cl.items, []client.Correspondent{
 		{ID: 15818, Name: "bank", Slug: "aslug"},
@@ -103,5 +107,8 @@ paperless_correspondent_info{id="24467",name="employer",slug=""} 1
 paperless_correspondent_last_correspondence_timestamp_seconds{id="15818"} 0
 paperless_correspondent_last_correspondence_timestamp_seconds{id="167"} 1.5619392e+09
 paperless_correspondent_last_correspondence_timestamp_seconds{id="24467"} 0
+# HELP paperless_warnings_total Number of warnings generated while scraping metrics.
+# TYPE paperless_warnings_total gauge
+paperless_warnings_total 0
 `)
 }

--- a/document_test.go
+++ b/document_test.go
@@ -66,7 +66,11 @@ func TestDocumentCollect(t *testing.T) {
 
 	c := newMultiCollector(newDocumentCollector(&cl))
 
-	testutil.CollectAndCompare(t, c, ``)
+	testutil.CollectAndCompare(t, c, `
+# HELP paperless_warnings_total Number of warnings generated while scraping metrics.
+# TYPE paperless_warnings_total gauge
+paperless_warnings_total 0
+`)
 
 	cl.count = 11921
 
@@ -74,5 +78,8 @@ func TestDocumentCollect(t *testing.T) {
 # HELP paperless_documents Number of documents.
 # TYPE paperless_documents gauge
 paperless_documents 11921
+# HELP paperless_warnings_total Number of warnings generated while scraping metrics.
+# TYPE paperless_warnings_total gauge
+paperless_warnings_total 0
 `)
 }

--- a/document_test.go
+++ b/document_test.go
@@ -64,7 +64,7 @@ func TestDocumentCollect(t *testing.T) {
 		count: client.ItemCountUnknown,
 	}
 
-	c := newMultiCollector(newDocumentCollector(&cl))
+	c := newMultiCollectorForTest(t, newDocumentCollector(&cl))
 
 	testutil.CollectAndCompare(t, c, `
 # HELP paperless_warnings_total Number of warnings generated while scraping metrics.

--- a/documenttype_test.go
+++ b/documenttype_test.go
@@ -70,7 +70,7 @@ func TestDocumentType(t *testing.T) {
 func TestDocumentTypeCollect(t *testing.T) {
 	cl := fakeDocumentTypeClient{}
 
-	c := newMultiCollector(newDocumentTypeCollector(&cl))
+	c := newMultiCollectorForTest(t, newDocumentTypeCollector(&cl))
 
 	testutil.CollectAndCompare(t, c, `
 # HELP paperless_warnings_total Number of warnings generated while scraping metrics.

--- a/documenttype_test.go
+++ b/documenttype_test.go
@@ -72,7 +72,11 @@ func TestDocumentTypeCollect(t *testing.T) {
 
 	c := newMultiCollector(newDocumentTypeCollector(&cl))
 
-	testutil.CollectAndCompare(t, c, ``)
+	testutil.CollectAndCompare(t, c, `
+# HELP paperless_warnings_total Number of warnings generated while scraping metrics.
+# TYPE paperless_warnings_total gauge
+paperless_warnings_total 0
+`)
 
 	cl.items = append(cl.items, []client.DocumentType{
 		{ID: 3760, Name: "Contract", Slug: "contract"},
@@ -88,5 +92,8 @@ paperless_document_type_document_count{id="5558"} 20
 # TYPE paperless_document_type_info gauge
 paperless_document_type_info{id="3760",name="Contract",slug="contract"} 1
 paperless_document_type_info{id="5558",name="Purchase order",slug="po"} 1
+# HELP paperless_warnings_total Number of warnings generated while scraping metrics.
+# TYPE paperless_warnings_total gauge
+paperless_warnings_total 0
 `)
 }

--- a/group_test.go
+++ b/group_test.go
@@ -64,7 +64,7 @@ func TestGroupCollect(t *testing.T) {
 		count: client.ItemCountUnknown,
 	}
 
-	c := newMultiCollector(newGroupCollector(&cl))
+	c := newMultiCollectorForTest(t, newGroupCollector(&cl))
 
 	testutil.CollectAndCompare(t, c, `
 # HELP paperless_warnings_total Number of warnings generated while scraping metrics.

--- a/group_test.go
+++ b/group_test.go
@@ -66,7 +66,11 @@ func TestGroupCollect(t *testing.T) {
 
 	c := newMultiCollector(newGroupCollector(&cl))
 
-	testutil.CollectAndCompare(t, c, ``)
+	testutil.CollectAndCompare(t, c, `
+# HELP paperless_warnings_total Number of warnings generated while scraping metrics.
+# TYPE paperless_warnings_total gauge
+paperless_warnings_total 0
+`)
 
 	cl.count = 321
 
@@ -74,5 +78,8 @@ func TestGroupCollect(t *testing.T) {
 # HELP paperless_groups Number of user groups.
 # TYPE paperless_groups gauge
 paperless_groups 321
+# HELP paperless_warnings_total Number of warnings generated while scraping metrics.
+# TYPE paperless_warnings_total gauge
+paperless_warnings_total 0
 `)
 }

--- a/log_test.go
+++ b/log_test.go
@@ -118,11 +118,19 @@ func TestLogCollect(t *testing.T) {
 
 	c := newMultiCollector(newLogCollector(&cl))
 
-	testutil.CollectAndCompare(t, c, "")
+	testutil.CollectAndCompare(t, c, `
+# HELP paperless_warnings_total Number of warnings generated while scraping metrics.
+# TYPE paperless_warnings_total gauge
+paperless_warnings_total 0
+`)
 
 	cl.names = append(cl.names, "server", "db", "not found")
 
-	testutil.CollectAndCompare(t, c, "")
+	testutil.CollectAndCompare(t, c, `
+# HELP paperless_warnings_total Number of warnings generated while scraping metrics.
+# TYPE paperless_warnings_total gauge
+paperless_warnings_total 0
+`)
 
 	cl.addEntries("server", []client.LogEntry{
 		{
@@ -141,6 +149,9 @@ func TestLogCollect(t *testing.T) {
 # TYPE paperless_log_entries_total counter
 paperless_log_entries_total{level="",module="storage",name="server"} 1
 paperless_log_entries_total{level="another",module="storage",name="server"} 1
+# HELP paperless_warnings_total Number of warnings generated while scraping metrics.
+# TYPE paperless_warnings_total gauge
+paperless_warnings_total 0
 `)
 
 	cl.addEntries("server", []client.LogEntry{
@@ -163,6 +174,9 @@ paperless_log_entries_total{level="another",module="storage",name="server"} 1
 paperless_log_entries_total{level="",module="",name="db"} 1
 paperless_log_entries_total{level="",module="storage",name="server"} 2
 paperless_log_entries_total{level="another",module="storage",name="server"} 1
+# HELP paperless_warnings_total Number of warnings generated while scraping metrics.
+# TYPE paperless_warnings_total gauge
+paperless_warnings_total 0
 `)
 
 		// Reset logs

--- a/log_test.go
+++ b/log_test.go
@@ -116,7 +116,7 @@ func TestLogCollect(t *testing.T) {
 		entries: map[string][]client.LogEntry{},
 	}
 
-	c := newMultiCollector(newLogCollector(&cl))
+	c := newMultiCollectorForTest(t, newLogCollector(&cl))
 
 	testutil.CollectAndCompare(t, c, `
 # HELP paperless_warnings_total Number of warnings generated while scraping metrics.

--- a/multicollector_test.go
+++ b/multicollector_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"io"
+	"log"
+	"testing"
+)
+
+func newMultiCollectorForTest(t *testing.T, m multiCollectorMember) *multiCollector {
+	t.Helper()
+
+	c := newMultiCollector(m)
+	c.logger = log.New(io.Discard, "", 0)
+
+	return c
+}

--- a/remote_version.go
+++ b/remote_version.go
@@ -36,8 +36,6 @@ func (c *remoteVersionCollector) collect(ctx context.Context, ch chan<- promethe
 
 	if remoteVersion, _, err := c.cl.GetRemoteVersion(ctx); err != nil {
 		ch <- newWarning(fmt.Errorf("fetching remote version: %w", err))
-	} else if remoteVersion.Version == "" {
-		return nil
 	} else {
 		version = remoteVersion.Version
 

--- a/remote_version.go
+++ b/remote_version.go
@@ -36,11 +36,14 @@ func (c *remoteVersionCollector) collect(ctx context.Context, ch chan<- promethe
 
 	if remoteVersion, _, err := c.cl.GetRemoteVersion(ctx); err != nil {
 		ch <- newWarning(fmt.Errorf("fetching remote version: %w", err))
-	} else if len(remoteVersion.Version) == 0 {
+	} else if remoteVersion.Version == "" {
 		return nil
-	} else if remoteVersion.UpdateAvailable {
-		updateAvailable = 1
+	} else {
 		version = remoteVersion.Version
+
+		if remoteVersion.UpdateAvailable {
+			updateAvailable = 1
+		}
 	}
 
 	ch <- prometheus.MustNewConstMetric(c.updateAvailableDesc, prometheus.GaugeValue, updateAvailable, version)

--- a/remote_version_test.go
+++ b/remote_version_test.go
@@ -102,6 +102,22 @@ paperless_warnings_total 0
 `,
 		},
 		{
+			name: "no version",
+			cl: fakeRemoteVersionClient{
+				result: client.RemoteVersion{
+					UpdateAvailable: true,
+				},
+			},
+			want: `
+# HELP paperless_remote_version_update_available Whether an update is available.
+# TYPE paperless_remote_version_update_available gauge
+paperless_remote_version_update_available{version=""} 1
+# HELP paperless_warnings_total Number of warnings generated while scraping metrics.
+# TYPE paperless_warnings_total gauge
+paperless_warnings_total 0
+`,
+		},
+		{
 			name: "failure",
 			cl: fakeRemoteVersionClient{
 				err: errTest,

--- a/remote_version_test.go
+++ b/remote_version_test.go
@@ -93,7 +93,7 @@ paperless_warnings_total 1
 				err: tc.err,
 			}
 
-			c := newMultiCollector(newRemoteVersionCollector(&cl))
+			c := newMultiCollectorForTest(t, newRemoteVersionCollector(&cl))
 
 			testutil.CollectAndCompare(t, c, tc.want)
 		})

--- a/remote_version_test.go
+++ b/remote_version_test.go
@@ -68,7 +68,7 @@ func TestRemoteVersionCollect(t *testing.T) {
 		want string
 	}{
 		{
-			name: "success",
+			name: "available",
 			cl: fakeRemoteVersionClient{
 				result: client.RemoteVersion{
 					UpdateAvailable: true,
@@ -79,6 +79,23 @@ func TestRemoteVersionCollect(t *testing.T) {
 # HELP paperless_remote_version_update_available Whether an update is available.
 # TYPE paperless_remote_version_update_available gauge
 paperless_remote_version_update_available{version="1.2.3"} 1
+# HELP paperless_warnings_total Number of warnings generated while scraping metrics.
+# TYPE paperless_warnings_total gauge
+paperless_warnings_total 0
+`,
+		},
+		{
+			name: "no update",
+			cl: fakeRemoteVersionClient{
+				result: client.RemoteVersion{
+					UpdateAvailable: false,
+					Version:         "1.2.3",
+				},
+			},
+			want: `
+# HELP paperless_remote_version_update_available Whether an update is available.
+# TYPE paperless_remote_version_update_available gauge
+paperless_remote_version_update_available{version="1.2.3"} 0
 # HELP paperless_warnings_total Number of warnings generated while scraping metrics.
 # TYPE paperless_warnings_total gauge
 paperless_warnings_total 0

--- a/remote_version_test.go
+++ b/remote_version_test.go
@@ -66,5 +66,8 @@ func TestRemoteVersionCollect(t *testing.T) {
 # HELP paperless_remote_version_update_available Whether an update is available.
 # TYPE paperless_remote_version_update_available gauge
 paperless_remote_version_update_available{version="1.2.3"} 1
+# HELP paperless_warnings_total Number of warnings generated while scraping metrics.
+# TYPE paperless_warnings_total gauge
+paperless_warnings_total 0
 `)
 }

--- a/statistics_test.go
+++ b/statistics_test.go
@@ -81,7 +81,7 @@ func TestStatistics(t *testing.T) {
 func TestStatisticsCollect(t *testing.T) {
 	cl := fakeStatisticsClient{}
 
-	c := newMultiCollector(newStatisticsCollector(&cl))
+	c := newMultiCollectorForTest(t, newStatisticsCollector(&cl))
 
 	testutil.CollectAndCompare(t, c, `
 # HELP paperless_statistics_character_count Number of characters stored across the total number of documents.

--- a/statistics_test.go
+++ b/statistics_test.go
@@ -109,5 +109,8 @@ paperless_statistics_storage_path_count 0
 # HELP paperless_statistics_tag_count Total number of tags.
 # TYPE paperless_statistics_tag_count gauge
 paperless_statistics_tag_count 55
+# HELP paperless_warnings_total Number of warnings generated while scraping metrics.
+# TYPE paperless_warnings_total gauge
+paperless_warnings_total 0
 `)
 }

--- a/status_test.go
+++ b/status_test.go
@@ -121,5 +121,8 @@ paperless_status_storage_available_bytes 1.3406437376e+10
 # HELP paperless_status_storage_total_bytes Total storage of Paperless in bytes.
 # TYPE paperless_status_storage_total_bytes gauge
 paperless_status_storage_total_bytes 2.147483648e+10
+# HELP paperless_warnings_total Number of warnings generated while scraping metrics.
+# TYPE paperless_warnings_total gauge
+paperless_warnings_total 0
 `)
 }

--- a/status_test.go
+++ b/status_test.go
@@ -88,7 +88,7 @@ func TestStatus(t *testing.T) {
 func TestStatusCollect(t *testing.T) {
 	cl := fakeStatusClient{}
 
-	c := newMultiCollector(newStatusCollector(&cl))
+	c := newMultiCollectorForTest(t, newStatusCollector(&cl))
 
 	testutil.CollectAndCompare(t, c, `
 # HELP paperless_status_celery_status Status of celery. 1 is OK, 0 is not OK.

--- a/storagepath_test.go
+++ b/storagepath_test.go
@@ -72,7 +72,11 @@ func TestStoragePathCollect(t *testing.T) {
 
 	c := newMultiCollector(newStoragePathCollector(&cl))
 
-	testutil.CollectAndCompare(t, c, ``)
+	testutil.CollectAndCompare(t, c, `
+# HELP paperless_warnings_total Number of warnings generated while scraping metrics.
+# TYPE paperless_warnings_total gauge
+paperless_warnings_total 0
+`)
 
 	cl.items = append(cl.items, []client.StoragePath{
 		{ID: 23547, Name: "personal", Slug: "personal"},
@@ -88,5 +92,8 @@ paperless_storage_path_document_count{id="704"} 13
 # TYPE paperless_storage_path_info gauge
 paperless_storage_path_info{id="23547",name="personal",slug="personal"} 1
 paperless_storage_path_info{id="704",name="work",slug=""} 1
+# HELP paperless_warnings_total Number of warnings generated while scraping metrics.
+# TYPE paperless_warnings_total gauge
+paperless_warnings_total 0
 `)
 }

--- a/storagepath_test.go
+++ b/storagepath_test.go
@@ -70,7 +70,7 @@ func TestStoragePath(t *testing.T) {
 func TestStoragePathCollect(t *testing.T) {
 	cl := fakeStoragePathClient{}
 
-	c := newMultiCollector(newStoragePathCollector(&cl))
+	c := newMultiCollectorForTest(t, newStoragePathCollector(&cl))
 
 	testutil.CollectAndCompare(t, c, `
 # HELP paperless_warnings_total Number of warnings generated while scraping metrics.

--- a/tag_test.go
+++ b/tag_test.go
@@ -73,7 +73,7 @@ func TestTag(t *testing.T) {
 func TestTagCollect(t *testing.T) {
 	cl := fakeTagClient{}
 
-	c := newMultiCollector(newTagCollector(&cl))
+	c := newMultiCollectorForTest(t, newTagCollector(&cl))
 
 	testutil.CollectAndCompare(t, c, `
 # HELP paperless_warnings_total Number of warnings generated while scraping metrics.

--- a/tag_test.go
+++ b/tag_test.go
@@ -75,7 +75,11 @@ func TestTagCollect(t *testing.T) {
 
 	c := newMultiCollector(newTagCollector(&cl))
 
-	testutil.CollectAndCompare(t, c, ``)
+	testutil.CollectAndCompare(t, c, `
+# HELP paperless_warnings_total Number of warnings generated while scraping metrics.
+# TYPE paperless_warnings_total gauge
+paperless_warnings_total 0
+`)
 
 	cl.items = append(cl.items, []client.Tag{
 		{ID: 8463, Name: "aaa", Slug: "aslug"},
@@ -103,5 +107,8 @@ paperless_tag_info{id="26429",name="last",slug=""} 1
 paperless_tag_info{id="2930",name="mybox",slug="mb"} 1
 paperless_tag_info{id="338",name="three-three-eight",slug=""} 1
 paperless_tag_info{id="8463",name="aaa",slug="aslug"} 1
+# HELP paperless_warnings_total Number of warnings generated while scraping metrics.
+# TYPE paperless_warnings_total gauge
+paperless_warnings_total 0
 `)
 }

--- a/task_test.go
+++ b/task_test.go
@@ -63,7 +63,7 @@ func TestTask(t *testing.T) {
 func TestTaskCollect(t *testing.T) {
 	cl := fakeTaskClient{}
 
-	c := newMultiCollector(newTaskCollector(&cl))
+	c := newMultiCollectorForTest(t, newTaskCollector(&cl))
 
 	testutil.CollectAndCompare(t, c, `
 # HELP paperless_task_status_info Task status names.

--- a/task_test.go
+++ b/task_test.go
@@ -69,6 +69,9 @@ func TestTaskCollect(t *testing.T) {
 # HELP paperless_task_status_info Task status names.
 # TYPE paperless_task_status_info gauge
 paperless_task_status_info{status="success"} 1
+# HELP paperless_warnings_total Number of warnings generated while scraping metrics.
+# TYPE paperless_warnings_total gauge
+paperless_warnings_total 0
 `)
 
 	cl.tasks = append(cl.tasks, client.Task{
@@ -96,5 +99,8 @@ paperless_task_status{id="31563",status="statusunspecified"} 1
 # TYPE paperless_task_status_info gauge
 paperless_task_status_info{status="statusunspecified"} 1
 paperless_task_status_info{status="success"} 1
+# HELP paperless_warnings_total Number of warnings generated while scraping metrics.
+# TYPE paperless_warnings_total gauge
+paperless_warnings_total 0
 `)
 }

--- a/user_test.go
+++ b/user_test.go
@@ -66,7 +66,11 @@ func TestUserCollect(t *testing.T) {
 
 	c := newMultiCollector(newUserCollector(&cl))
 
-	testutil.CollectAndCompare(t, c, ``)
+	testutil.CollectAndCompare(t, c, `
+# HELP paperless_warnings_total Number of warnings generated while scraping metrics.
+# TYPE paperless_warnings_total gauge
+paperless_warnings_total 0
+`)
 
 	cl.count = 6799
 
@@ -74,5 +78,8 @@ func TestUserCollect(t *testing.T) {
 # HELP paperless_users Number of users.
 # TYPE paperless_users gauge
 paperless_users 6799
+# HELP paperless_warnings_total Number of warnings generated while scraping metrics.
+# TYPE paperless_warnings_total gauge
+paperless_warnings_total 0
 `)
 }

--- a/user_test.go
+++ b/user_test.go
@@ -64,7 +64,7 @@ func TestUserCollect(t *testing.T) {
 		count: client.ItemCountUnknown,
 	}
 
-	c := newMultiCollector(newUserCollector(&cl))
+	c := newMultiCollectorForTest(t, newUserCollector(&cl))
 
 	testutil.CollectAndCompare(t, c, `
 # HELP paperless_warnings_total Number of warnings generated while scraping metrics.

--- a/warning.go
+++ b/warning.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"os"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// warning is a special form of a metric and suitable for reporting non-fatal
+// errors during a scrape. Warnings are only logged and not forwarded to the
+// registry.
+type warning struct {
+	err error
+}
+
+var _ prometheus.Metric = (*warning)(nil)
+
+func newWarning(err error) *warning {
+	return &warning{err}
+}
+
+func (*warning) Desc() *prometheus.Desc {
+	return nil
+}
+
+func (*warning) Write(*dto.Metric) error {
+	return os.ErrInvalid
+}


### PR DESCRIPTION
Emit a warning (a new concept) when the API request checking for updates fails. The scrape as a whole succeeds now. Fixes #65.

Report remote version metric even when the version string is empty. It's not up to the exporter to determine what is a good or bad version string. Fixes #66.